### PR TITLE
Add support for JSON arrays

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -1048,6 +1048,8 @@ func TestToStringSliceE(t *testing.T) {
 		expect []string
 		iserr  bool
 	}{
+		{`["a", "b"]`, []string{"a", "b"}, false},
+		{"a b", []string{"a", "b"}, false},
 		{[]string{"a", "b"}, []string{"a", "b"}, false},
 		{[]interface{}{1, 3}, []string{"1", "3"}, false},
 		{interface{}(1), []string{"1"}, false},

--- a/caste.go
+++ b/caste.go
@@ -1130,6 +1130,9 @@ func ToStringSliceE(i interface{}) ([]string, error) {
 	case []string:
 		return v, nil
 	case string:
+		if err := json.Unmarshal([]byte(v), &a); err == nil {
+			return a, nil
+		}
 		return strings.Fields(v), nil
 	case interface{}:
 		str, err := ToStringE(v)


### PR DESCRIPTION
### What does this PR do?

Allow parsing strings as JSON arrays in addition to space-separated items.

### Motivation

Be consistent with maps, that do already support JSON formatted content.

### Additional Notes

Original upstream issue: https://github.com/spf13/cast/issues/62